### PR TITLE
Add Industrial config to reduce Core clk

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -680,6 +680,9 @@ config SOC_SERIES_IMX_RT11XX
 config INIT_ARM_PLL
 	bool "Initialize ARM PLL"
 
+config SOC_MIMXRT1176_CM7_INDUSTRIAL
+	bool "Set ARM Clock to 600MHz (max for industrial)"
+
 config INIT_VIDEO_PLL
 	bool "Initialize Video PLL"
 

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -170,7 +170,8 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 
 /* RT1160 does not have Forward Body Biasing on the CM7 core */
-#if defined(CONFIG_SOC_MIMXRT1176_CM4) || defined(CONFIG_SOC_MIMXRT1176_CM7)
+#if defined(CONFCONFIG_SOC_MIMXRT1176_CM7_INDUSTRIAL) 
+#elif defined(CONFIG_SOC_MIMXRT1176_CM4) || defined(CONFIG_SOC_MIMXRT1176_CM7)
 	/* Check if FBB need to be enabled in OverDrive(OD) mode */
 	if (((OCOTP->FUSEN[7].FUSE & 0x10U) >> 4U) != 1) {
 		PMU_EnableBodyBias(ANADIG_PMU, kPMU_FBB_CM7, true);

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -56,7 +56,15 @@
 
 #ifdef CONFIG_INIT_ARM_PLL
 static const clock_arm_pll_config_t armPllConfig = {
-#if defined(CONFIG_SOC_MIMXRT1176_CM4) || defined(CONFIG_SOC_MIMXRT1176_CM7)
+	
+#if defined(CONFIG_SOC_MIMXRT1176_CM7_INDUSTRIAL)
+	/* resulting frequency: 24 * (200/(2 * 4)) = 600MHz */
+	/* Post divider, 0 - DIV by 2, 1 - DIV by 4, 2 - DIV by 8, 3 - DIV by 1 */
+	.postDivider = kCLOCK_PllPostDiv4,
+	/* PLL Loop divider, Fout = Fin * ( loopDivider / ( 2 * postDivider ) ) */
+	.loopDivider = 200,
+
+#elif defined(CONFIG_SOC_MIMXRT1176_CM4) || defined(CONFIG_SOC_MIMXRT1176_CM7)
 	/* resulting frequency: 24 * (166/(2* 2)) = 984MHz */
 	/* Post divider, 0 - DIV by 2, 1 - DIV by 4, 2 - DIV by 8, 3 - DIV by 1 */
 	.postDivider = kCLOCK_PllPostDiv2,

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -56,7 +56,7 @@
 
 #ifdef CONFIG_INIT_ARM_PLL
 static const clock_arm_pll_config_t armPllConfig = {
-	
+
 #if defined(CONFIG_SOC_MIMXRT1176_CM7_INDUSTRIAL)
 	/* resulting frequency: 24 * (200/(2 * 4)) = 600MHz */
 	/* Post divider, 0 - DIV by 2, 1 - DIV by 4, 2 - DIV by 8, 3 - DIV by 1 */
@@ -70,6 +70,7 @@ static const clock_arm_pll_config_t armPllConfig = {
 	.postDivider = kCLOCK_PllPostDiv2,
 	/* PLL Loop divider, Fout = Fin * ( loopDivider / ( 2 * postDivider ) ) */
 	.loopDivider = 166,
+
 #elif defined(CONFIG_SOC_MIMXRT1166_CM4) || defined(CONFIG_SOC_MIMXRT1166_CM7)
 	/* resulting frequency: 24 * (200/(2 * 4)) = 600MHz */
 	/* Post divider, 0 - DIV by 2, 1 - DIV by 4, 2 - DIV by 8, 3 - DIV by 1 */
@@ -170,7 +171,7 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 
 /* RT1160 does not have Forward Body Biasing on the CM7 core */
-#if defined(CONFCONFIG_SOC_MIMXRT1176_CM7_INDUSTRIAL) 
+#if defined(CONFIG_SOC_MIMXRT1176_CM7_INDUSTRIAL)
 #elif defined(CONFIG_SOC_MIMXRT1176_CM4) || defined(CONFIG_SOC_MIMXRT1176_CM7)
 	/* Check if FBB need to be enabled in OverDrive(OD) mode */
 	if (((OCOTP->FUSEN[7].FUSE & 0x10U) >> 4U) != 1) {


### PR DESCRIPTION
Adds an Industrial config, to set ARM CLK to 600 instead 996MHz